### PR TITLE
Separate -> Separate typo

### DIFF
--- a/Materials/Part_3_Feature_Engineering.html
+++ b/Materials/Part_3_Feature_Engineering.html
@@ -719,7 +719,7 @@ ggplot(
 
 # Interactions &lt;img src="images/ggplot2.png" class="title-hex"&gt;
 
-However... what if we seperate this trend based on whether the property has air conditioning (93.4% of the training set) or not (6.6%):
+However... what if we separate this trend based on whether the property has air conditioning (93.4% of the training set) or not (6.6%):
 
 .pull-left[
 


### PR DESCRIPTION
Changed “seperate” to “separate” on line 722.